### PR TITLE
mc_test.py: Fixed missing import for altMinSense

### DIFF
--- a/mc_test.py
+++ b/mc_test.py
@@ -6,6 +6,7 @@ import scipy.sparse as sparse
 import matplotlib.pyplot as plt
 
 from mc_util import *
+from mc_solve import altMinSense
 
 def main():
     np.random.seed(1)


### PR DESCRIPTION
`mc_test.py` calls `altMinSense` which is in `mc_solve`, but never imports it. This fixes that minor error.